### PR TITLE
One more speed up to PAM250.

### DIFF
--- a/msresist/clustering.py
+++ b/msresist/clustering.py
@@ -55,7 +55,7 @@ class MassSpecClustering(BaseEstimator):
             binoM = GenerateBPM(cl_seqs, background)
             seq_scores = assignPeptidesBN(self.ncl, sequences, cl_seqs, background, binoM, self.labels_)
         else:
-            seq_scores = assignPeptidesPAM(self.ncl, sequences, cl_seqs, background, self.labels_)
+            seq_scores = assignPeptidesPAM(self.ncl, cl_seqs, background, self.labels_)
 
         return seq_scores
 

--- a/msresist/expectation_maximization.py
+++ b/msresist/expectation_maximization.py
@@ -41,7 +41,7 @@ def EM_clustering(data, info, ncl, SeqWeight, distance_method, max_n_iter):
             binoM = GenerateBPM(cl_seqs, background)
             seq_scores = assignPeptidesBN(ncl, sequences, cl_seqs, background, binoM, new_labels)
         else:
-            seq_scores = assignPeptidesPAM(ncl, sequences, cl_seqs, background, new_labels)
+            seq_scores = assignPeptidesPAM(ncl, cl_seqs, background, new_labels)
 
         final_scores = seq_scores * SeqWeight + gmmp
         SeqIdx = np.argmax(seq_scores, axis=1)

--- a/msresist/pam250.py
+++ b/msresist/pam250.py
@@ -51,14 +51,14 @@ def pairwise_score(seq1: str, seq2: str) -> float:
     return score
 
 
-def assignPeptidesPAM(ncl, sequences, cl_seqs, Seq1Seq2ToScore, labels):
+def assignPeptidesPAM(ncl, cl_seqs, Seq1Seq2ToScore, labels):
     """E-step––Do the peptide assignment according to sequence and data"""
-    seq_scores = np.zeros((len(sequences), ncl))
+    seq_scores = np.zeros((Seq1Seq2ToScore.shape[0], ncl))
 
     # Average distance between each sequence and any cluster based on PAM250 substitution matrix
-    for j, motif in enumerate(sequences):
-        for idx, assignments in enumerate(labels):
-            seq_scores[j, assignments] += Seq1Seq2ToScore[j, idx]
+    for j in range(Seq1Seq2ToScore.shape[0]):
+        for z in range(ncl):
+            seq_scores[j, z] = np.sum(Seq1Seq2ToScore[j, labels == z])
 
     for z in range(ncl):
         seq_scores[:, z] /= len(cl_seqs[z])  # average score per cluster


### PR DESCRIPTION
@mcreixell profiling came up with this one last improvement. I'll merge it now. With this, running the model is proportional to the number of peptides, with:

- 2000: 22 sec
- 4000: 28 sec
- 8000: 66.6 sec
- 16000: 219 sec