### PR TITLE
Another way of deleting the background matrix

### DIFF
--- a/msresist/clustering.py
+++ b/msresist/clustering.py
@@ -35,6 +35,10 @@ class MassSpecClustering(BaseEstimator):
         """Compute EM clustering"""
         self.avgScores_, self.scores_, self.seq_scores_, self.gmm_ = EM_clustering_repeat(nRepeats, X, self.info, self.ncl, self.dist)
 
+        if self.distance_method == "PAM250":
+            for ii in range(self.ncl):
+                self.gmm_.distributions[ii][-1].background = None
+
         return self
 
     def wins(self, X):


### PR DESCRIPTION
This deletes the background matrix in the PAM250 classes for pickling. After doing this, one should be able to pickle and unpickle the classes like usual without the set/get functions. Note that this doesn't have to be done where I put it, and after this is performed the GMM will not be able to run the fitting process anymore.