### PR TITLE
Explore nans

### DIFF
--- a/msresist/binomial.py
+++ b/msresist/binomial.py
@@ -165,7 +165,7 @@ class Binomial(CustomDistribution):
         betaA = np.clip(betaA, 0.01, np.inf)
         probmat = sc.betainc(betaA, k + 1, 1 - self.background[0])
         self.logWeights[:] = self.SeqWeight * np.log(np.tensordot(self.background[1], probmat, axes=2))
-        self.logWeights[:] = self.logWeights - np.mean(self.logWeights)
+        self.logWeights[:] = self.logWeights - np.average(self.logWeights)
 
 
 def unpackBinomial(seq, seqs, sw, lw, frozen):

--- a/msresist/binomial.py
+++ b/msresist/binomial.py
@@ -165,7 +165,7 @@ class Binomial(CustomDistribution):
         betaA = np.clip(betaA, 0.01, np.inf)
         probmat = sc.betainc(betaA, k + 1, 1 - self.background[0])
         self.logWeights[:] = self.SeqWeight * np.log(np.tensordot(self.background[1], probmat, axes=2))
-        self.logWeights[:] = self.logWeights - np.average(self.logWeights)
+        self.logWeights[:] = self.logWeights - np.amax(self.logWeights)
 
 
 def unpackBinomial(seq, seqs, sw, lw, frozen):

--- a/msresist/pam250.py
+++ b/msresist/pam250.py
@@ -37,7 +37,7 @@ class PAM250(CustomDistribution):
         else:
             self.logWeights[:] = self.SeqWeight * np.average(self.background, weights=self.weightsIn, axis=0)
 
-        self.logWeights[:] = self.logWeights - np.mean(self.logWeights)
+        self.logWeights[:] = self.logWeights - np.average(self.logWeights)
 
 
 class fixedMotif(CustomDistribution):

--- a/msresist/pam250.py
+++ b/msresist/pam250.py
@@ -37,7 +37,7 @@ class PAM250(CustomDistribution):
         else:
             self.logWeights[:] = self.SeqWeight * np.average(self.background, weights=self.weightsIn, axis=0)
 
-        self.logWeights[:] = self.logWeights - np.average(self.logWeights)
+        self.logWeights[:] = self.logWeights - np.amax(self.logWeights)
 
 
 class fixedMotif(CustomDistribution):

--- a/msresist/tests/test_CoClustering.py
+++ b/msresist/tests/test_CoClustering.py
@@ -27,8 +27,8 @@ def test_wins(distance_method):
     assert distances[0] < distances[1]
 
 
-@pytest.mark.parametrize("w", [0, 0.1, 0.3, 1])
-@pytest.mark.parametrize("ncl", [2, 3, 4])
+@pytest.mark.parametrize("w", [0.0, 1.0, 100.0])
+@pytest.mark.parametrize("ncl", [2, 5, 6])
 @pytest.mark.parametrize("distance_method", ["PAM250", "Binomial", "PAM250_fixed"])
 def test_clusters(w, ncl, distance_method):
     """ Test that EMclustering is working by comparing with GMM clusters. """


### PR DESCRIPTION
np.amax() and np.mean() both generate different clusters whereas np.sum() generates the same clusters. min_std() doesn't seem to affect anything. I'm seeing that the model always breaks when the weight is very high. I reduced SeqWeight from 100 to 20 and still breaks most of the time. We can discuss in a bit.