### PR TITLE
update STK11 LR model.

### DIFF
--- a/msresist/figures/figureM6.py
+++ b/msresist/figures/figureM6.py
@@ -65,7 +65,7 @@ def makeFigure():
 
     # Logistic Regression
     centers["STK11"] = y_["STK11.mutation.status"].values
-    lr = LogisticRegressionCV(Cs=10, cv=10, solver="saga", max_iter=100000, tol=1e-4, n_jobs=-1, penalty="l1", class_weight="balanced")
+    lr = LogisticRegressionCV(cv=5, solver="saga", max_iter=100000, tol=1e-4, n_jobs=-1, penalty="elasticnet", l1_ratios=[0.1])
     plotROC(ax[1], lr, centers.iloc[:, :-1].values, centers["STK11"], cv_folds=4, title="ROC STK11")
     ax[1].legend(loc='lower right', prop={'size': 8})
     plotClusterCoefficients(ax[2], lr.fit(centers.iloc[:, :-1], centers["STK11"].values), list(centers.columns[:-1]), title="STK11")

--- a/msresist/figures/figureMS6.py
+++ b/msresist/figures/figureMS6.py
@@ -85,7 +85,7 @@ def makeFigure():
 def plot_ROCs(ax, centers, centers_min, X, y, gene_label):
     """Generate ROC plots using DDMC, unclustered, k-means, and GMM for a particular feature."""
     # LASSO
-    lr = LogisticRegressionCV(Cs=10, cv=10, solver="saga", max_iter=10000, n_jobs=-1, penalty="l1", class_weight="balanced")
+    lr = LogisticRegressionCV(cv=5, solver="saga", max_iter=100000, tol=1e-4, n_jobs=-1, penalty="elasticnet", l1_ratios=[0.1])
 
     folds = 7
 


### PR DESCRIPTION
Changed the regularization parameters from `l2` to `elasticnet` with a `l1_ratios` of 0.1. Also, I removed the `class_weight` to `balanced` and set it to default (`None`). These settings were the only combination I found to have cluster 7 contribute as much. 

![image](https://user-images.githubusercontent.com/46428799/117203761-46dc0c00-ada4-11eb-8769-9a4d777a5819.png)
