### PR TITLE
reduce size motifs.

### DIFF
--- a/manuscripts/method/04.discussion.md
+++ b/manuscripts/method/04.discussion.md
@@ -17,8 +17,3 @@ Moreover, an additional major challenge being faced during the analysis of large
 
 <!-- Conclusion / Closure -->
 Conclusively, in this study we show that combining the information about the sequence features and phosphorylation abundance leads to more robust clustering of global signaling measurements. Moreover, subsequent use of DDMC cluster to regress against cell phenotypes led to enhanced model predictions and interpretation. Thus, we propose DDMC as a general and flexible strategy for phosphoproteomic analysis. 
-
-
-
-
-

--- a/msresist/figures/figureMS2.py
+++ b/msresist/figures/figureMS2.py
@@ -3,6 +3,7 @@ This creates Supplemental Figure 2: Cluster motifs
 """
 
 import pickle
+import numpy as np 
 from .common import subplotLabel, getSetup
 from .figure2 import plotMotifs
 
@@ -10,15 +11,23 @@ from .figure2 import plotMotifs
 def makeFigure():
     """Get a list of the axis objects and create a figure"""
     # Get list of axis objects
-    ax, f = getSetup((7, 11), (6, 4))
+    ax, f = getSetup((7, 10), (6, 4))
 
     with open('msresist/data/pickled_models/binomial/CPTACmodel_BINOMIAL_CL24_W15_TMT2', 'rb') as p:
         model = pickle.load(p)[0]
 
     pssms = model.pssms(PsP_background=False)
+    ylabels = np.arange(0, 21, 4)
+    xlabels = [20, 21, 22, 23, 24]
     for ii in range(model.ncl):
         cluster = "Cluster " + str(ii + 1)
         plotMotifs([pssms[ii]], axes=[ax[ii]], titles=[cluster], yaxis=[0, 10])
+        if ii not in ylabels:
+            ax[ii].set_ylabel("")
+            ax[ii].get_yaxis().set_visible(False)
+        elif ii not in xlabels:
+            ax[ii].set_xlabel("")
+            ax[ii].get_xaxis().set_visible(False)
 
     # Add subplot labels
     subplotLabel(ax)


### PR DESCRIPTION
This just formats the supplemental figure with all cluster PSSMs to (hopefully) fit in one page. 